### PR TITLE
feat: add zadd and zrevrange implementations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "source": "https://github.com/momentohq/momento-php-redis-client"
   },
   "require": {
-    "momentohq/client-sdk-php": "v1.13.0",
+    "momentohq/client-sdk-php": "dev-main",
     "vlucas/phpdotenv": "^5.6",
     "ext-redis": "*"
   },
@@ -43,6 +43,8 @@
       "php": "8.0.2"
     }
   },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "scripts": {
     "lint": "phpcs -s --standard=phpcs.xml src/",
     "lint-fix": "phpcbf --standard=phpcs.xml src/",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2ef3c865773304b153af004bd65e4b23",
+    "content-hash": "78012dbb009782c5422c82cb4b7e69aa",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -177,16 +177,16 @@
         },
         {
             "name": "momentohq/client-sdk-php",
-            "version": "v1.13.0",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/momentohq/client-sdk-php.git",
-                "reference": "da5a7e8834be0a35b693d67e80152b10cf06168f"
+                "reference": "d5719a86367d08072ea63a51673328223582b3bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/momentohq/client-sdk-php/zipball/da5a7e8834be0a35b693d67e80152b10cf06168f",
-                "reference": "da5a7e8834be0a35b693d67e80152b10cf06168f",
+                "url": "https://api.github.com/repos/momentohq/client-sdk-php/zipball/d5719a86367d08072ea63a51673328223582b3bf",
+                "reference": "d5719a86367d08072ea63a51673328223582b3bf",
                 "shasum": ""
             },
             "require": {
@@ -203,6 +203,7 @@
                 "friendsofphp/php-cs-fixer": "3.64.0",
                 "phpunit/phpunit": "^9.5.23"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "files": [
@@ -251,7 +252,7 @@
                 "issues": "https://github.com/momentohq/client-sdk-php/issues",
                 "source": "https://github.com/momentohq/client-sdk-php"
             },
-            "time": "2024-10-15T20:54:26+00:00"
+            "time": "2024-10-18T17:42:41+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -3873,16 +3874,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.6",
+            "version": "1.12.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "dc4d2f145a88ea7141ae698effd64d9df46527ae"
+                "reference": "dc2b9976bd8b0f84ec9b0e50cc35378551de7af0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dc4d2f145a88ea7141ae698effd64d9df46527ae",
-                "reference": "dc4d2f145a88ea7141ae698effd64d9df46527ae",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dc2b9976bd8b0f84ec9b0e50cc35378551de7af0",
+                "reference": "dc2b9976bd8b0f84ec9b0e50cc35378551de7af0",
                 "shasum": ""
             },
             "require": {
@@ -3927,7 +3928,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-06T15:03:59+00:00"
+            "time": "2024-10-18T11:12:07+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4917,16 +4918,16 @@
         },
         {
             "name": "rector/rector",
-            "version": "1.2.7",
+            "version": "1.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "5b33bdd871895276e2c18e5410a4a57df9233ee0"
+                "reference": "05755bf43617449c08ee8e50fb840c85ad3b1240"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/5b33bdd871895276e2c18e5410a4a57df9233ee0",
-                "reference": "5b33bdd871895276e2c18e5410a4a57df9233ee0",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/05755bf43617449c08ee8e50fb840c85ad3b1240",
+                "reference": "05755bf43617449c08ee8e50fb840c85ad3b1240",
                 "shasum": ""
             },
             "require": {
@@ -4964,7 +4965,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/1.2.7"
+                "source": "https://github.com/rectorphp/rector/tree/1.2.8"
             },
             "funding": [
                 {
@@ -4972,7 +4973,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-12T11:12:46+00:00"
+            "time": "2024-10-18T11:54:27+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -8948,9 +8949,11 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
-    "stability-flags": {},
-    "prefer-stable": false,
+    "minimum-stability": "dev",
+    "stability-flags": {
+        "momentohq/client-sdk-php": 20
+    },
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "ext-redis": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -181,12 +181,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/momentohq/client-sdk-php.git",
-                "reference": "d5719a86367d08072ea63a51673328223582b3bf"
+                "reference": "9e6236716bc608dbec9f6f53b35d6b35c9169a5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/momentohq/client-sdk-php/zipball/d5719a86367d08072ea63a51673328223582b3bf",
-                "reference": "d5719a86367d08072ea63a51673328223582b3bf",
+                "url": "https://api.github.com/repos/momentohq/client-sdk-php/zipball/9e6236716bc608dbec9f6f53b35d6b35c9169a5b",
+                "reference": "9e6236716bc608dbec9f6f53b35d6b35c9169a5b",
                 "shasum": ""
             },
             "require": {
@@ -252,7 +252,7 @@
                 "issues": "https://github.com/momentohq/client-sdk-php/issues",
                 "source": "https://github.com/momentohq/client-sdk-php"
             },
-            "time": "2024-10-18T17:42:41+00:00"
+            "time": "2024-10-18T22:16:21+00:00"
         },
         {
             "name": "phpoption/phpoption",

--- a/src/MomentoCacheClient.php
+++ b/src/MomentoCacheClient.php
@@ -1960,8 +1960,10 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         $result = $this->client->sortedSetPutElements($this->cacheName, $key, $elements);
         if ($result->asSuccess()) {
             return count($elements);
-        } else {
+        } elseif ($result->asError()) {
             return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+        } else {
+            return false;
         }
     }
 
@@ -2134,10 +2136,12 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
                 }
                 return $members;
             }
-        } else if ($result->asMiss()) {
+        } elseif ($result->asMiss()) {
             return [];
-        } else {
+        } elseif ($result->asError()) {
             return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+        } else {
+            return false;
         }
     }
 

--- a/src/MomentoCacheClient.php
+++ b/src/MomentoCacheClient.php
@@ -2127,11 +2127,9 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
             $end = null;
         }
 
-        var_dump("start: $start, end: $end");
         $result = $this->client->sortedSetFetchByRank($this->cacheName, $key, $start, $end, SORT_DESC);
         if ($result->asHit()) {
             $elements = $result->asHit()->valuesArray();
-            var_dump($elements);
             if ($scores === true) {
                 return $elements;
             } else {

--- a/tests/MomentoRedisClientTest.php
+++ b/tests/MomentoRedisClientTest.php
@@ -558,57 +558,62 @@ class MomentoRedisClientTest extends TestCase
     /**
      * @throws RedisException
      */
-    public function testZRevRangeWithValidRanks(): void
+    public function testZRevRangeWithAllRanks(): void
     {
         $key = uniqid();
         $member1 = uniqid();
         $member2 = uniqid();
         $member3 = uniqid();
+        $member4 = uniqid();
         $score1 = 1.0;
         $score2 = 2.0;
         $score3 = 3.0;
+        $score4 = 4.0;
 
-        $result = self::$client->zAdd($key, $score1, $member1, $score2, $member2, $score3, $member3);
-        $this->assertEquals(3, $result, "Failed to add multiple members with scores");
+        $result = self::$client->zAdd($key, $score1, $member1, $score2, $member2, $score3, $member3, $score4, $member4);
+        $this->assertEquals(4, $result, "Failed to add multiple members with scores");
 
-        // Test valid rank range with positive start and end
+        // Test 1: Both start and end are positive, start < end
         $elements = self::$client->zRevRange($key, 0, 2);
-        $this->assertEquals([$member3, $member2, $member1], $elements, "Elements do not match expected order for positive ranks");
+        $this->assertCount(3, $elements, "Expected 3 elements for range 0-2");
+        $this->assertEquals([$member4, $member3, $member2], $elements, "Retrieved elements do not match the expected elements");
 
-        // Test valid rank range with negative start and end
+        // Test 2: Both start and end are positive, start == end
+        $elements = self::$client->zRevRange($key, 1, 1);
+        $this->assertCount(1, $elements, "Expected 1 element for range 1-1");
+
+        // Test 3: Both start and end are positive, start > end
+        $elements = self::$client->zRevRange($key, 2, 0);
+        $this->assertEmpty($elements, "Expected empty array for range 2-0");
+
+        // Test 4: Both start and end are negative, start < end
         $elements = self::$client->zRevRange($key, -3, -1);
-        $this->assertEquals([$member3, $member2, $member1], $elements, "Elements do not match expected order for negative ranks");
+        $this->assertCount(3, $elements, "Expected to fetch 3 elements for negative range -3 to -1");
+        $this->assertEquals([$member3, $member2, $member1], $elements, "Retrieved elements do not match the expected elements for negative range");
 
-        // Test valid rank range with positive start and negative end
+        // Test 5: Both start and end are negative, start == end
+        $elements = self::$client->zRevRange($key, -2, -2);
+        $this->assertCount(1, $elements, "Expected 1 element for negative range -2 to -2");
+        $this->assertEquals([$member2], $elements, "Retrieved elements do not match the expected elements for negative range");
+
+        // Test 6: Both start and end are negative, start > end
+        $elements = self::$client->zRevRange($key, -1, -3);
+        $this->assertCount(0, $elements, "Expected to fetch 0 elements for invalid range -1 to -3");
+
+        // Test 7: Mixed positive and negative ranks, start positive and end negative
+        $elements = self::$client->zRevRange($key, 0, -2);
+        $this->assertCount(3, $elements, "Expected to fetch 3 elements for mixed range 0 to -2");
+        $this->assertEquals([$member4, $member3, $member2], $elements, "Retrieved elements do not match the expected elements for mixed range");
+
+        // Test 8: Mixed positive and negative ranks, start negative and end positive
+        $elements = self::$client->zRevRange($key, -3, 2);
+        $this->assertCount(2, $elements, "Expected to fetch 2 elements for mixed range -3 to 2");
+        $this->assertEquals([$member3, $member2], $elements, "Retrieved elements do not match the expected elements for mixed range");
+
+        // Test 9: Unbounded end, should fetch all elements
         $elements = self::$client->zRevRange($key, 0, -1);
-        $this->assertEquals([$member3, $member2, $member1], $elements, "Elements do not match expected order for mixed ranks");
-
-         // Test valid rank range with a subset of elements
-        $elements = self::$client->zRevRange($key, 1, 2);
-        $this->assertEquals([$member2, $member1], $elements, "Elements do not match expected order for a subset of elements");
-    }
-
-    /**
-     * @throws RedisException
-     */
-    public function testZRevRangeWithInvalidRanks(): void
-    {
-        $key = uniqid();
-        $member1 = uniqid();
-        $member2 = uniqid();
-        $score1 = 1.0;
-        $score2 = 2.0;
-
-        $result = self::$client->zAdd($key, $score1, $member1, $score2, $member2);
-        $this->assertEquals(2, $result, "Failed to add multiple members with scores");
-
-        // Test with start greater than end for positive ranks
-        $result = self::$client->zRevRange($key, 2, 1);
-        $this->assertEmpty($result, "Expected empty array for invalid ranks");
-
-        // Test with start greater than end for negative ranks
-        $result = self::$client->zRevRange($key, -1, -2);
-        $this->assertEmpty($result, "Expected empty array for invalid ranks");
+        $this->assertCount(4, $elements, "Expected to fetch all elements with unbounded end");
+        $this->assertEquals([$member4, $member3, $member2, $member1], $elements, "Elements do not match expected order for unbounded end");
     }
 
     /**


### PR DESCRIPTION
## PR Description:
- Implement `zadd` and `zrevrange` methods
- Add integration tests

## Testing
- Developing the methods by basing them off of the [main branch of client-sdk-php repo](https://github.com/momentohq/client-sdk-php/tree/main) [check composer.json]

## Issue
https://github.com/momentohq/dev-eco-issue-tracker/issues/1033