### PR TITLE
chore: add makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,10 +47,10 @@ jobs:
           tools: composer
 
       - name: Install dependencies
-        run: composer install
+        run: make install
 
       - name: Check CS (Code Style)
-        run: composer lint
+        run: make lint-check
 
   test:
     runs-on: ubuntu-latest
@@ -90,19 +90,13 @@ jobs:
           tools: composer
 
       - name: Install dependencies
-        run: composer install
+        run: make install
 
       - name: Run tests with Momento backend
         env:
           MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
           TEST_REDIS: false
-        run: |
-          echo "Running tests with Momento backend"
-          composer test
+        run: make test-momento
 
       - name: Run tests with Redis backend
-        env:
-          TEST_REDIS: true
-        run: |
-          echo "Running tests with Redis backend"
-          composer test
+        run: make test-redis

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.PHONY: install lint-check lint test-momento test-redis test-redis-docker test test-docker
+
+install:
+	@echo "Installing dependencies..."
+	@composer install
+
+lint-check:
+	@echo "Checking code style..."
+	@composer lint
+
+lint:
+	@echo "Fixing code style..."
+	@composer lint-fix
+
+test-momento:
+	@echo "Running momento-backed tests..."
+	@composer test
+
+test-redis:
+	@echo "Running redis-backed tests..."
+	@TEST_REDIS=1 composer test
+
+test-redis-docker:
+	@REDIS_HOST=redis make test-redis
+
+test: test-momento test-redis
+
+test-docker: test-momento test-redis-docker

--- a/tests/SetupIntegrationTest.php
+++ b/tests/SetupIntegrationTest.php
@@ -35,7 +35,8 @@ class SetupIntegrationTest
 
     public static function isRedisBackedTest(): bool
     {
-        return getenv('TEST_REDIS') === 'true';
+        $test_redis_env = getenv('TEST_REDIS');
+        return $test_redis_env === 'true' || $test_redis_env === '1';
     }
 
     /**


### PR DESCRIPTION
Adds a project makefile with install, lint-check, lint, and test targets. We divide the test targets by testing vs momento and vs redis. For the latter we provide targets for testing in docker vs outside. We adjust the CI to invoke the make targets.