### PR TITLE
feat: implement zunionstore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,6 @@
   "scripts": {
     "lint": "phpcs -s --standard=phpcs.xml src/",
     "lint-fix": "phpcbf --standard=phpcs.xml src/",
-    "test": "./vendor/bin/phpunit tests/MomentoRedisClientTest.php"
+    "test": "./vendor/bin/phpunit tests"
   }
 }

--- a/src/IMomentoRedisClient.php
+++ b/src/IMomentoRedisClient.php
@@ -19,4 +19,5 @@ interface IMomentoRedisClient
     public function zRem(mixed $key, mixed $member, mixed ...$other_members): Redis|int|false;
     public function zRevRange(string $key, int $start, int $end, mixed $scores = null): Redis|array|false;
     public function zScore(string $key, mixed $member): Redis|float|false;
+    public function zunionstore(string $dst, array $keys, ?array $weights = null, ?string $aggregate = null): Redis|int|false;
 }

--- a/src/MomentoCacheClient.php
+++ b/src/MomentoCacheClient.php
@@ -2305,9 +2305,13 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
 
     public function zunionstore(string $dst, array $keys, ?array $weights = null, ?string $aggregate = null): Redis|int|false
     {
-        // In phpredis, improper weights or aggregate results in a runtime exception.
-        $weights = ZunionstoreOptionsHelper::validateAndPrepareWeights($weights, count($keys));
-        $aggregate = ZunionstoreOptionsHelper::validateAndPrepareAggregate($aggregate);
+        // In phpredis, improper weights or aggregate results in a runtime warning and returning false.
+        try {
+            $weights = ZunionstoreOptionsHelper::validateAndPrepareWeights($weights, count($keys));
+            $aggregate = ZunionstoreOptionsHelper::validateAndPrepareAggregate($aggregate);
+        } catch (InvalidArgumentException $e) {
+            return false;
+        }
 
         // Perform asynchronous fetches from each sorted set
         $futures = [];

--- a/src/Utils/ZunionstoreOptionsHelper.php
+++ b/src/Utils/ZunionstoreOptionsHelper.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Momento\Cache\Utils;
+
+class ZunionstoreOptionsHelper
+{
+    // Static constants for aggregation options
+    const AGGREGATE_SUM = 'sum';
+    const AGGREGATE_MIN = 'min';
+    const AGGREGATE_MAX = 'max';
+
+    /**
+     * Validates and normalizes the weights.
+     *
+     * @param array|null $weights The weights provided by the user.
+     * @param int $keyCount The number of keys.
+     * @return array The normalized weights array.
+     * @throws \InvalidArgumentException if the weights are invalid.
+     */
+    public static function validateAndPrepareWeights(?array $weights, int $keyCount): array
+    {
+        if (is_null($weights)) {
+            // Defaults to 1 for each key
+            return array_fill(0, $keyCount, 1.0);
+        }
+
+        // Must have the same number of weights as keys
+        if (count($weights) !== $keyCount) {
+            throw new \InvalidArgumentException("Number of weights must match the number of keys.");
+        }
+
+        // Weights must be numeric
+        foreach ($weights as $weight) {
+            if (!is_numeric($weight)) {
+                throw new \InvalidArgumentException("All weights must be integers or floats.");
+            }
+        }
+
+        return $weights;
+    }
+
+    /**
+     * Validates and normalizes the aggregation function.
+     *
+     * @param string|null $aggregate The aggregation function (sum, min, max).
+     * @return string The normalized aggregation function.
+     * @throws \InvalidArgumentException if the aggregation function is invalid.
+     */
+    public static function validateAndPrepareAggregate(?string $aggregate): string
+    {
+        // Default to sum
+        if (is_null($aggregate)) {
+            return self::AGGREGATE_SUM;
+        }
+
+        $aggregate = strtolower($aggregate);
+        if (!in_array($aggregate, [self::AGGREGATE_SUM, self::AGGREGATE_MIN, self::AGGREGATE_MAX])) {
+            throw new \InvalidArgumentException("Invalid aggregate option. Must be 'sum', 'min', or 'max'.");
+        }
+
+        return $aggregate;
+    }
+}

--- a/tests/MomentoRedisClientTest.php
+++ b/tests/MomentoRedisClientTest.php
@@ -1002,12 +1002,10 @@ class MomentoRedisClientTest extends TestCase
         $this->assertEquals($expected, $storedValues, "The stored result in $dst should match the expected min values.");
     }
 
-    public function testZunionstore_WithInvalidWeights_ShouldThrowException(): void
+    public function testZunionstore_WithInvalidWeights_ShouldReturnFalse(): void
     {
-        if (self::$isRedisBackendTest) {
-            $this->markTestSkipped("This test is only for Momento client");
-        }
-        $this->expectException(\InvalidArgumentException::class);
+        // Temporarily suppress warnings for this test: needed to suppress warnings on redis test
+        $originalErrorReporting = error_reporting(E_ALL & ~E_WARNING);
 
         $key1 = uniqid();
         $key2 = uniqid();
@@ -1018,16 +1016,17 @@ class MomentoRedisClientTest extends TestCase
         self::$client->zAdd($key2, 2.0, 'b');
 
         // Attempt zunionstore with invalid weights (mismatched count)
-        self::$client->zunionstore($dst, [$key1, $key2], [1.0]);
+        $result = self::$client->zunionstore($dst, [$key1, $key2], [1.0]);
+        $this->assertFalse($result);
+
+        // Restore the original error reporting level
+        error_reporting($originalErrorReporting);
     }
 
-    public function testZunionstore_WithInvalidAggregate_ShouldThrowException(): void
+    public function testZunionstore_WithInvalidAggregate_ShouldReturnFalse(): void
     {
-        if (self::$isRedisBackendTest) {
-            $this->markTestSkipped("This test is only for Momento client");
-        }
-
-        $this->expectException(\InvalidArgumentException::class);
+        // Temporarily suppress warnings for this test: needed to suppress warnings on redis test
+        $originalErrorReporting = error_reporting(E_ALL & ~E_WARNING);
 
         $key1 = uniqid();
         $key2 = uniqid();
@@ -1038,7 +1037,12 @@ class MomentoRedisClientTest extends TestCase
         self::$client->zAdd($key2, 2.0, 'b');
 
         // Attempt zunionstore with an invalid aggregate function
-        self::$client->zunionstore($dst, [$key1, $key2], null, 'invalid_aggregate');
+        $result = self::$client->zunionstore($dst, [$key1, $key2], null, 'invalid_aggregate');
+        $this->assertFalse($result);
+
+
+        // Restore the original error reporting level
+        error_reporting($originalErrorReporting);
     }
 
     public function testZunionstore_WithEmptySortedSets_ShouldReturnZero(): void

--- a/tests/Utils/RangeValueTest.php
+++ b/tests/Utils/RangeValueTest.php
@@ -2,12 +2,8 @@
 
 namespace Utils;
 
-use Momento\Cache\Errors\InvalidArgumentError;
-use Momento\Cache\Errors\NotImplementedException;
-use Momento\Cache\MomentoCacheClient;
 use Momento\Cache\Utils\RangeValue;
 use PHPUnit\Framework\TestCase;
-use SetupIntegrationTest;
 
 class RangeValueTest extends TestCase
 {

--- a/tests/Utils/ZunionstoreOptionsHelperTest.php
+++ b/tests/Utils/ZunionstoreOptionsHelperTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Utils;
+
+use Momento\Cache\Utils\ZunionstoreOptionsHelper;
+use PHPUnit\Framework\TestCase;
+
+class ZunionstoreOptionsHelperTest extends TestCase
+{
+    public function testValidateAndPrepareWeights_WithNullWeights_ShouldReturnDefaultWeights(): void
+    {
+        $keyCount = 3;
+        $weights = null;
+        $expected = [1.0, 1.0, 1.0];
+
+        $result = ZunionstoreOptionsHelper::validateAndPrepareWeights($weights, $keyCount);
+        $this->assertEquals($expected, $result, "Default weights should be [1.0, 1.0, 1.0]");
+    }
+
+    public function testValidateAndPrepareWeights_WithValidWeights_ShouldReturnWeights(): void
+    {
+        $keyCount = 3;
+        $weights = [2.0, 3.5, 1.0];
+
+        $result = ZunionstoreOptionsHelper::validateAndPrepareWeights($weights, $keyCount);
+        $this->assertEquals($weights, $result, "Weights should be returned as provided.");
+    }
+
+    public function testValidateAndPrepareWeights_WithMismatchedCount_ShouldThrowException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Number of weights must match the number of keys.");
+
+        $keyCount = 3;
+        $weights = [2.0, 3.5]; // Only two weights for three keys
+
+        ZunionstoreOptionsHelper::validateAndPrepareWeights($weights, $keyCount);
+    }
+
+    public function testValidateAndPrepareWeights_WithNonNumericWeight_ShouldThrowException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("All weights must be integers or floats.");
+
+        $keyCount = 3;
+        $weights = [2.0, "invalid", 1.0]; // One of the weights is a string
+
+        ZunionstoreOptionsHelper::validateAndPrepareWeights($weights, $keyCount);
+    }
+
+    public function testValidateAndPrepareAggregate_WithNullAggregate_ShouldReturnSum(): void
+    {
+        $aggregate = null;
+        $expected = ZunionstoreOptionsHelper::AGGREGATE_SUM;
+
+        $result = ZunionstoreOptionsHelper::validateAndPrepareAggregate($aggregate);
+        $this->assertEquals($expected, $result, "Aggregate should default to 'sum'.");
+    }
+
+    public function testValidateAndPrepareAggregate_WithValidAggregate_ShouldReturnAggregate(): void
+    {
+        $aggregate = 'MIN';
+        $expected = ZunionstoreOptionsHelper::AGGREGATE_MIN;
+
+        $result = ZunionstoreOptionsHelper::validateAndPrepareAggregate($aggregate);
+        $this->assertEquals($expected, $result, "Aggregate should return 'min'.");
+    }
+
+    public function testValidateAndPrepareAggregate_WithInvalidAggregate_ShouldThrowException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid aggregate option. Must be 'sum', 'min', or 'max'.");
+
+        $aggregate = 'invalid'; // Invalid aggregation function
+
+        ZunionstoreOptionsHelper::validateAndPrepareAggregate($aggregate);
+    }
+
+    public function testValidateAndPrepareWeights_WithIntegerWeights_ShouldPass(): void
+    {
+        $keyCount = 3;
+        $weights = [1, 2, 3];
+
+        $result = ZunionstoreOptionsHelper::validateAndPrepareWeights($weights, $keyCount);
+        $this->assertEquals($weights, $result, "Integer weights should be allowed and returned as-is.");
+    }
+
+    public function testValidateAndPrepareWeights_WithMixedNumericWeights_ShouldPass(): void
+    {
+        $keyCount = 3;
+        $weights = [1, 2.5, 3];
+
+        $result = ZunionstoreOptionsHelper::validateAndPrepareWeights($weights, $keyCount);
+        $this->assertEquals($weights, $result, "Mixed integer and float weights should be allowed.");
+    }
+
+    public function testValidateAndPrepareAggregate_CaseInsensitive_ShouldPass(): void
+    {
+        $aggregate = 'MiN'; // Case-insensitive input
+        $expected = ZunionstoreOptionsHelper::AGGREGATE_MIN;
+
+        $result = ZunionstoreOptionsHelper::validateAndPrepareAggregate($aggregate);
+        $this->assertEquals($expected, $result, "Aggregate function should be case-insensitive.");
+    }
+
+    public function testValidateAndPrepareAggregate_WithSum_ShouldReturnSum(): void
+    {
+        $aggregate = 'sum';
+        $expected = ZunionstoreOptionsHelper::AGGREGATE_SUM;
+
+        $result = ZunionstoreOptionsHelper::validateAndPrepareAggregate($aggregate);
+        $this->assertEquals($expected, $result, "Aggregate should return 'sum'.");
+    }
+
+    public function testValidateAndPrepareAggregate_WithMax_ShouldReturnMax(): void
+    {
+        $aggregate = 'max';
+        $expected = ZunionstoreOptionsHelper::AGGREGATE_MAX;
+
+        $result = ZunionstoreOptionsHelper::validateAndPrepareAggregate($aggregate);
+        $this->assertEquals($expected, $result, "Aggregate should return 'max'.");
+    }
+
+    public function testValidateAndPrepareAggregate_WithUpperCaseSum_ShouldReturnSum(): void
+    {
+        $aggregate = 'SuM'; // Case-insensitive input
+        $expected = ZunionstoreOptionsHelper::AGGREGATE_SUM;
+
+        $result = ZunionstoreOptionsHelper::validateAndPrepareAggregate($aggregate);
+        $this->assertEquals($expected, $result, "Aggregate should return 'sum', case-insensitively.");
+    }
+
+    public function testValidateAndPrepareAggregate_WithUpperCaseMax_ShouldReturnMax(): void
+    {
+        $aggregate = 'MAX'; // Case-insensitive input
+        $expected = ZunionstoreOptionsHelper::AGGREGATE_MAX;
+
+        $result = ZunionstoreOptionsHelper::validateAndPrepareAggregate($aggregate);
+        $this->assertEquals($expected, $result, "Aggregate should return 'max', case-insensitively.");
+    }
+}


### PR DESCRIPTION
Implements zunionstore and integration tests. Adds a helper class to
validate and return the weights and aggregation options. Adds unit
tests for that helper.

Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1033
