### PR TITLE
feat: use released sdk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     "source": "https://github.com/momentohq/momento-php-redis-client"
   },
   "require": {
-    "momentohq/client-sdk-php": "dev-main",
     "vlucas/phpdotenv": "^5.6",
     "ext-redis": "*"
   },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
   },
   "require": {
     "vlucas/phpdotenv": "^5.6",
-    "ext-redis": "*"
+    "ext-redis": "*",
+    "momentohq/client-sdk-php": "^1.14"
   },
   "require-dev": {
     "orchestra/testbench": "^7.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,71 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "05c727ef38b82497e441dc1e085c634d",
+    "content-hash": "7b1573e9fcad0c8f15656e2c0fbf1520",
     "packages": [
+        {
+            "name": "firebase/php-jwt",
+            "version": "v6.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/firebase/php-jwt.git",
+                "reference": "500501c2ce893c824c801da135d02661199f60c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/500501c2ce893c824c801da135d02661199f60c5",
+                "reference": "500501c2ce893c824c801da135d02661199f60c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.4",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/cache": "^2.0||^3.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/firebase/php-jwt/issues",
+                "source": "https://github.com/firebase/php-jwt/tree/v6.10.1"
+            },
+            "time": "2024-05-18T18:05:11+00:00"
+        },
         {
             "name": "graham-campbell/result-type",
             "version": "v1.1.3",
@@ -67,6 +130,128 @@
                 }
             ],
             "time": "2024-07-20T21:45:45+00:00"
+        },
+        {
+            "name": "grpc/grpc",
+            "version": "1.57.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/grpc/grpc-php.git",
+                "reference": "b610c42022ed3a22f831439cb93802f2a4502fdf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/b610c42022ed3a22f831439cb93802f2a4502fdf",
+                "reference": "b610c42022ed3a22f831439cb93802f2a4502fdf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "google/auth": "^v1.3.0"
+            },
+            "suggest": {
+                "ext-protobuf": "For better performance, install the protobuf C extension.",
+                "google/protobuf": "To get started using grpc quickly, install the native protobuf library."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Grpc\\": "src/lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "gRPC library for PHP",
+            "homepage": "https://grpc.io",
+            "keywords": [
+                "rpc"
+            ],
+            "support": {
+                "source": "https://github.com/grpc/grpc-php/tree/v1.57.0"
+            },
+            "time": "2023-08-14T23:57:54+00:00"
+        },
+        {
+            "name": "momentohq/client-sdk-php",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/momentohq/client-sdk-php.git",
+                "reference": "4985fede7e09415beaaa7f633c3de6b2b0d85b4c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/momentohq/client-sdk-php/zipball/4985fede7e09415beaaa7f633c3de6b2b0d85b4c",
+                "reference": "4985fede7e09415beaaa7f633c3de6b2b0d85b4c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-grpc": "*",
+                "ext-protobuf": "*",
+                "firebase/php-jwt": "^6.3",
+                "grpc/grpc": "1.57.0",
+                "php": ">=7.4",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "psr/simple-cache": "^1.0.1 || ^3.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.4.1",
+                "friendsofphp/php-cs-fixer": "3.64.0",
+                "phpunit/phpunit": "^9.5.23"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Utilities/_DataValidation.php"
+                ],
+                "psr-4": {
+                    "Auth\\": "types/Auth/",
+                    "Store\\": "types/Store/",
+                    "Token\\": "types/Token/",
+                    "Common\\": "types/Common/",
+                    "Momento\\": "src/",
+                    "Webhook\\": "types/Webhook/",
+                    "GPBMetadata\\": "types/GPBMetadata/",
+                    "Leaderboard\\": "types/Leaderboard/",
+                    "Cache_client\\": "types/Cache_client/",
+                    "Control_client\\": "types/Control_client/",
+                    "Permission_messages\\": "types/Permission_messages/"
+                },
+                "classmap": [
+                    "src/Cache/CacheOperationTypes/CacheOperationTypes.php",
+                    "src/Storage/StorageOperationTypes/StorageOperationTypes.php",
+                    "src/Cache/Errors/Errors.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Momento",
+                    "email": "eng-deveco@momentohq.com",
+                    "homepage": "https://www.gomomento.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP SDK for Momento, a serverless cache that automatically scales without any of the operational overhead required by traditional caching solutions.",
+            "homepage": "https://github.com/momentohq/client-sdk-php",
+            "keywords": [
+                "cache",
+                "caching",
+                "serverless"
+            ],
+            "support": {
+                "email": "support@momentohq.com",
+                "issues": "https://github.com/momentohq/client-sdk-php/issues",
+                "source": "https://github.com/momentohq/client-sdk-php"
+            },
+            "time": "2024-10-25T17:20:04+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -142,6 +327,107 @@
                 }
             ],
             "time": "2024-07-20T21:41:07+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
+            },
+            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4323,107 +4609,6 @@
                 "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
             "time": "2023-04-04T09:54:51+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.2"
-            },
-            "time": "2024-09-11T13:17:53+00:00"
-        },
-        {
-            "name": "psr/simple-cache",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
-                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\SimpleCache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interfaces for simple caching",
-            "keywords": [
-                "cache",
-                "caching",
-                "psr",
-                "psr-16",
-                "simple-cache"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
-            },
-            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "psy/psysh",

--- a/composer.lock
+++ b/composer.lock
@@ -4,71 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0acdb5c89c8c7206e28c2429aad9f8ba",
+    "content-hash": "05c727ef38b82497e441dc1e085c634d",
     "packages": [
-        {
-            "name": "firebase/php-jwt",
-            "version": "v6.10.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "500501c2ce893c824c801da135d02661199f60c5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/500501c2ce893c824c801da135d02661199f60c5",
-                "reference": "500501c2ce893c824c801da135d02661199f60c5",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.0"
-            },
-            "require-dev": {
-                "guzzlehttp/guzzle": "^7.4",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5",
-                "psr/cache": "^2.0||^3.0",
-                "psr/http-client": "^1.0",
-                "psr/http-factory": "^1.0"
-            },
-            "suggest": {
-                "ext-sodium": "Support EdDSA (Ed25519) signatures",
-                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Firebase\\JWT\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Neuman Vong",
-                    "email": "neuman+pear@twilio.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Anant Narayanan",
-                    "email": "anant@php.net",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
-            "homepage": "https://github.com/firebase/php-jwt",
-            "keywords": [
-                "jwt",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.10.1"
-            },
-            "time": "2024-05-18T18:05:11+00:00"
-        },
         {
             "name": "graham-campbell/result-type",
             "version": "v1.1.3",
@@ -130,129 +67,6 @@
                 }
             ],
             "time": "2024-07-20T21:45:45+00:00"
-        },
-        {
-            "name": "grpc/grpc",
-            "version": "1.57.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/grpc/grpc-php.git",
-                "reference": "b610c42022ed3a22f831439cb93802f2a4502fdf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/b610c42022ed3a22f831439cb93802f2a4502fdf",
-                "reference": "b610c42022ed3a22f831439cb93802f2a4502fdf",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.0.0"
-            },
-            "require-dev": {
-                "google/auth": "^v1.3.0"
-            },
-            "suggest": {
-                "ext-protobuf": "For better performance, install the protobuf C extension.",
-                "google/protobuf": "To get started using grpc quickly, install the native protobuf library."
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Grpc\\": "src/lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "description": "gRPC library for PHP",
-            "homepage": "https://grpc.io",
-            "keywords": [
-                "rpc"
-            ],
-            "support": {
-                "source": "https://github.com/grpc/grpc-php/tree/v1.57.0"
-            },
-            "time": "2023-08-14T23:57:54+00:00"
-        },
-        {
-            "name": "momentohq/client-sdk-php",
-            "version": "dev-main",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/momentohq/client-sdk-php.git",
-                "reference": "6e2163625c0e2ce8a3ed6f6ff51d0382e053c2fe"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/momentohq/client-sdk-php/zipball/6e2163625c0e2ce8a3ed6f6ff51d0382e053c2fe",
-                "reference": "6e2163625c0e2ce8a3ed6f6ff51d0382e053c2fe",
-                "shasum": ""
-            },
-            "require": {
-                "ext-grpc": "*",
-                "ext-protobuf": "*",
-                "firebase/php-jwt": "^6.3",
-                "grpc/grpc": "1.57.0",
-                "php": ">=7.4",
-                "psr/log": "^1.1 || ^2.0 || ^3.0",
-                "psr/simple-cache": "^1.0.1 || ^3.0"
-            },
-            "require-dev": {
-                "composer/composer": "^2.4.1",
-                "friendsofphp/php-cs-fixer": "3.64.0",
-                "phpunit/phpunit": "^9.5.23"
-            },
-            "default-branch": true,
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/Utilities/_DataValidation.php"
-                ],
-                "psr-4": {
-                    "Auth\\": "types/Auth/",
-                    "Store\\": "types/Store/",
-                    "Token\\": "types/Token/",
-                    "Common\\": "types/Common/",
-                    "Momento\\": "src/",
-                    "Webhook\\": "types/Webhook/",
-                    "GPBMetadata\\": "types/GPBMetadata/",
-                    "Leaderboard\\": "types/Leaderboard/",
-                    "Cache_client\\": "types/Cache_client/",
-                    "Control_client\\": "types/Control_client/",
-                    "Permission_messages\\": "types/Permission_messages/"
-                },
-                "classmap": [
-                    "src/Cache/CacheOperationTypes/CacheOperationTypes.php",
-                    "src/Storage/StorageOperationTypes/StorageOperationTypes.php",
-                    "src/Cache/Errors/Errors.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Momento",
-                    "email": "eng-deveco@momentohq.com",
-                    "homepage": "https://www.gomomento.com/",
-                    "role": "Developer"
-                }
-            ],
-            "description": "PHP SDK for Momento, a serverless cache that automatically scales without any of the operational overhead required by traditional caching solutions.",
-            "homepage": "https://github.com/momentohq/client-sdk-php",
-            "keywords": [
-                "cache",
-                "caching",
-                "serverless"
-            ],
-            "support": {
-                "email": "support@momentohq.com",
-                "issues": "https://github.com/momentohq/client-sdk-php/issues",
-                "source": "https://github.com/momentohq/client-sdk-php"
-            },
-            "time": "2024-10-21T22:41:24+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -328,107 +142,6 @@
                 }
             ],
             "time": "2024-07-20T21:41:07+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.2"
-            },
-            "time": "2024-09-11T13:17:53+00:00"
-        },
-        {
-            "name": "psr/simple-cache",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
-                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\SimpleCache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interfaces for simple caching",
-            "keywords": [
-                "cache",
-                "caching",
-                "psr",
-                "psr-16",
-                "simple-cache"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
-            },
-            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4610,6 +4323,107 @@
                 "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
             "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
+            },
+            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "psy/psysh",
@@ -8950,15 +8764,13 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "momentohq/client-sdk-php": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "ext-redis": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.0.2"
     },

--- a/src/MomentoCacheClient.php
+++ b/src/MomentoCacheClient.php
@@ -2008,8 +2008,8 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         $endValueForMomento = $endRangeValue->isFinite() ? $endRangeValue->getValue() : null;
         $result = $this->client->sortedSetLengthByScore(
             $this->cacheName, $key,
-            $startValueForMomento, $startRangeValue->isInclusive(),
-            $endValueForMomento, $endRangeValue->isInclusive());
+            $startValueForMomento, $endValueForMomento,
+            $startRangeValue->isInclusive(), $endRangeValue->isInclusive());
         if ($result->asHit()) {
             return $result->asHit()->length();
         } elseif ($result->asMiss()) {
@@ -2242,8 +2242,8 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
             $this->cacheName,
             $key,
             $minRangeValue->isFinite() ? $minRangeValue->getValue() : null,
-            $minRangeValue->isInclusive(),
             $maxRangeValue->isFinite() ? $maxRangeValue->getValue() : null,
+            $minRangeValue->isInclusive(),
             $maxRangeValue->isInclusive(),
             SORT_DESC,
             $limitStart,

--- a/src/MomentoCacheClient.php
+++ b/src/MomentoCacheClient.php
@@ -2004,11 +2004,9 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
             return false;
         }
 
-        $startValueForMomento = $startRangeValue->isFinite() ? $startRangeValue->getValue() : null;
-        $endValueForMomento = $endRangeValue->isFinite() ? $endRangeValue->getValue() : null;
         $result = $this->client->sortedSetLengthByScore(
             $this->cacheName, $key,
-            $startValueForMomento, $endValueForMomento,
+            $startRangeValue->getValueIfFiniteOrNull(), $endRangeValue->getValueIfFiniteOrNull(),
             $startRangeValue->isInclusive(), $endRangeValue->isInclusive());
         if ($result->asHit()) {
             return $result->asHit()->length();
@@ -2241,8 +2239,8 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         $result = $this->client->sortedSetFetchByScore(
             $this->cacheName,
             $key,
-            $minRangeValue->isFinite() ? $minRangeValue->getValue() : null,
-            $maxRangeValue->isFinite() ? $maxRangeValue->getValue() : null,
+            $minRangeValue->getValueIfFiniteOrNull(),
+            $maxRangeValue->getValueIfFiniteOrNull(),
             $minRangeValue->isInclusive(),
             $maxRangeValue->isInclusive(),
             SORT_DESC,

--- a/src/Utils/RangeValue.php
+++ b/src/Utils/RangeValue.php
@@ -98,6 +98,15 @@ class RangeValue
     }
 
     /**
+     * Get the value if it is finite, or null if it is infinite.
+     * @return float|int|null The value if it is finite, or null if it is infinite.
+     */
+    public function getValueIfFiniteOrNull(): float|int|null
+    {
+        return $this->isFinite() ? $this->value : null;
+    }
+
+    /**
      * Parse an input value to create a RangeValue object.
      *
      * The input can be an integer, float, or string. If the input is a numeric value,

--- a/tests/Utils/RangeValueTest.php
+++ b/tests/Utils/RangeValueTest.php
@@ -12,11 +12,13 @@ class RangeValueTest extends TestCase
         // Test inclusive integer parsing
         $rangeValue = RangeValue::parse(5);
         $this->assertEquals(5, $rangeValue->getValue());
+        $this->assertEquals($rangeValue->getValue(), $rangeValue->getValueIfFiniteOrNull());
         $this->assertTrue($rangeValue->isInclusive());
         $this->assertTrue($rangeValue->isFinite());
 
         $rangeValue = RangeValue::parse(-1);
         $this->assertEquals(-1, $rangeValue->getValue());
+        $this->assertEquals($rangeValue->getValue(), $rangeValue->getValueIfFiniteOrNull());
         $this->assertTrue($rangeValue->isInclusive());
         $this->assertTrue($rangeValue->isFinite());
     }
@@ -26,10 +28,12 @@ class RangeValueTest extends TestCase
         // Test inclusive float parsing
         $rangeValue = RangeValue::parse(5.75);
         $this->assertEquals(5.75, $rangeValue->getValue());
+        $this->assertEquals($rangeValue->getValue(), $rangeValue->getValueIfFiniteOrNull());
         $this->assertTrue($rangeValue->isInclusive());
 
         $rangeValue = RangeValue::parse(-1.25);
         $this->assertEquals(-1.25, $rangeValue->getValue());
+        $this->assertEquals($rangeValue->getValue(), $rangeValue->getValueIfFiniteOrNull());
         $this->assertTrue($rangeValue->isInclusive());
     }
 
@@ -38,10 +42,12 @@ class RangeValueTest extends TestCase
         // Test string-based integer parsing
         $rangeValue = RangeValue::parse("5");
         $this->assertEquals(5, $rangeValue->getValue());
+        $this->assertEquals($rangeValue->getValue(), $rangeValue->getValueIfFiniteOrNull());
         $this->assertTrue($rangeValue->isInclusive());
 
         $rangeValue = RangeValue::parse("-1");
         $this->assertEquals(-1, $rangeValue->getValue());
+        $this->assertEquals($rangeValue->getValue(), $rangeValue->getValueIfFiniteOrNull());
         $this->assertTrue($rangeValue->isInclusive());
     }
 
@@ -50,10 +56,12 @@ class RangeValueTest extends TestCase
         // Test string-based float parsing
         $rangeValue = RangeValue::parse("5.75");
         $this->assertEquals(5.75, $rangeValue->getValue());
+        $this->assertEquals($rangeValue->getValue(), $rangeValue->getValueIfFiniteOrNull());
         $this->assertTrue($rangeValue->isInclusive());
 
         $rangeValue = RangeValue::parse("-1.25");
         $this->assertEquals(-1.25, $rangeValue->getValue());
+        $this->assertEquals($rangeValue->getValue(), $rangeValue->getValueIfFiniteOrNull());
         $this->assertTrue($rangeValue->isInclusive());
     }
 
@@ -62,10 +70,12 @@ class RangeValueTest extends TestCase
         // Test exclusive integer parsing from string
         $rangeValue = RangeValue::parse("(5");
         $this->assertEquals(5, $rangeValue->getValue());
+        $this->assertEquals($rangeValue->getValue(), $rangeValue->getValueIfFiniteOrNull());
         $this->assertFalse($rangeValue->isInclusive());
 
         $rangeValue = RangeValue::parse("(-1");
         $this->assertEquals(-1, $rangeValue->getValue());
+        $this->assertEquals($rangeValue->getValue(), $rangeValue->getValueIfFiniteOrNull());
         $this->assertFalse($rangeValue->isInclusive());
     }
 
@@ -74,10 +84,12 @@ class RangeValueTest extends TestCase
         // Test exclusive float parsing from string
         $rangeValue = RangeValue::parse("(5.75");
         $this->assertEquals(5.75, $rangeValue->getValue());
+        $this->assertEquals($rangeValue->getValue(), $rangeValue->getValueIfFiniteOrNull());
         $this->assertFalse($rangeValue->isInclusive());
 
         $rangeValue = RangeValue::parse("(-1.25");
         $this->assertEquals(-1.25, $rangeValue->getValue());
+        $this->assertEquals($rangeValue->getValue(), $rangeValue->getValueIfFiniteOrNull());
         $this->assertFalse($rangeValue->isInclusive());
     }
 
@@ -86,12 +98,14 @@ class RangeValueTest extends TestCase
         // Test positive infinity
         $rangeValue = RangeValue::parse("+inf");
         $this->assertEquals("+inf", $rangeValue->getValue());
+        $this->assertNull($rangeValue->getValueIfFiniteOrNull());
         $this->assertFalse($rangeValue->isInclusive());
         $this->assertTrue($rangeValue->isPositiveInfinity());
         $this->assertFalse($rangeValue->isFinite());
 
         $rangeValue = RangeValue::parse("+INF");
         $this->assertEquals("+inf", $rangeValue->getValue());
+        $this->assertNull($rangeValue->getValueIfFiniteOrNull());
         $this->assertFalse($rangeValue->isInclusive());
         $this->assertTrue($rangeValue->isPositiveInfinity());
         $this->assertFalse($rangeValue->isFinite());
@@ -102,11 +116,13 @@ class RangeValueTest extends TestCase
         // Test negative infinity
         $rangeValue = RangeValue::parse("-inf");
         $this->assertEquals("-inf", $rangeValue->getValue());
+        $this->assertNull($rangeValue->getValueIfFiniteOrNull());
         $this->assertFalse($rangeValue->isInclusive());
         $this->assertTrue($rangeValue->isNegativeInfinity());
 
         $rangeValue = RangeValue::parse("-INF");
         $this->assertEquals("-inf", $rangeValue->getValue());
+        $this->assertNull($rangeValue->getValueIfFiniteOrNull());
         $this->assertFalse($rangeValue->isInclusive());
         $this->assertTrue($rangeValue->isNegativeInfinity());
     }


### PR DESCRIPTION
Uses the released SDK in the composer requirements instead of a GitHub commit hash. Fixes the code for the changes since the last version. We also add a convenience to parse the range values if finite or else get a null value.