### PR TITLE
feat: add pttl and ttl(seconds)

### DIFF
--- a/src/IMomentoRedisClient.php
+++ b/src/IMomentoRedisClient.php
@@ -13,6 +13,7 @@ interface IMomentoRedisClient
     public function set(string $key, string $value, mixed $options = null): mixed;
     public function setnx(string $key, mixed $value): Redis|bool;
     public function ttl(string $key): Redis|int|false;
+    public function pttl(string $key): Redis|int|false;
     public function zAdd(string $key, float|array $score_or_options, mixed ...$more_scores_and_mems): Redis|int|float|false;
     public function zCount(string $key, int|string $start, int|string $end): Redis|int|false;
     public function zIncrBy(string $key, float $value, mixed $member): Redis|float|false;

--- a/src/MomentoCacheClient.php
+++ b/src/MomentoCacheClient.php
@@ -1252,12 +1252,16 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         throw MomentoToPhpRedisExceptionMapper::createCommandNotImplementedException(__FUNCTION__);
     }
 
-    /**
-     * @throws Exception
-     */
     public function pttl(string $key): Redis|int|false
     {
-        throw MomentoToPhpRedisExceptionMapper::createCommandNotImplementedException(__FUNCTION__);
+        $result = $this->client->itemGetTtl($this->cacheName, $key);
+        if ($result->asHit()) {
+            return $result->asHit()->remainingTtlMillis();
+        } else if ($result->asMiss()) {
+            return -2;
+        } else {
+            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+        }
     }
 
     /**
@@ -1782,7 +1786,8 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
     {
         $result = $this->client->itemGetTtl($this->cacheName, $key);
         if ($result->asHit()) {
-            return $result->asHit()->remainingTtlMillis();
+            $ttl_ms = $result->asHit()->remainingTtlMillis();
+            return $ttl_ms / 1000;
         } else if ($result->asMiss()) {
             return -2;
         } else {

--- a/tests/MomentoRedisClientTest.php
+++ b/tests/MomentoRedisClientTest.php
@@ -323,9 +323,25 @@ class MomentoRedisClientTest extends TestCase
         $setResult = self::$client->set($key, $value, ['ex' => $ttlSeconds]);
         $this->assertEquals('OK', $setResult, "Failed to set the key-value pair");
 
-        $remainingTtlMillis = self::$client->ttl($key);
-        $this->assertGreaterThan(0, $remainingTtlMillis, "Expected TTL to be greater than 0");
-        $this->assertLessThanOrEqual($ttlSeconds * 1000, $remainingTtlMillis, "Expected TTL to be less than or equal to the set TTL");
+        $remainingTtlSeconds = self::$client->ttl($key);
+        $this->assertGreaterThan(0, $remainingTtlSeconds, "Expected TTL to be greater than 0");
+        $this->assertLessThanOrEqual($ttlSeconds, $remainingTtlSeconds, "Expected TTL to be less than or equal to the set TTL");
+    }
+
+    /**
+     * @throws RedisException
+     */
+    public function testPttl(): void
+    {
+        $key = uniqid();
+        $value = uniqid();
+        $ttlInMillis = round(microtime(true) * 1000) + 5000;
+        $setResult = self::$client->set($key, $value, ['pxat' => $ttlInMillis]);
+        $this->assertEquals('OK', $setResult, "Failed to set the key-value pair");
+
+        $remainingTtlMilliseconds = self::$client->pttl($key);
+        $this->assertGreaterThan(0, $remainingTtlMilliseconds, "Expected TTL to be greater than 0");
+        $this->assertLessThanOrEqual($ttlInMillis, $remainingTtlMilliseconds, "Expected TTL to be less than or equal to the set TTL");
     }
 
     /**


### PR DESCRIPTION
## PR Description:
- Add `pttl` method implementation
- Switch `ttl` logic for `pttl` i.e return time to live in milliseconds when `pttl` function is invoked, and in seconds when `ttl` function is invoked. 

## Issue
https://github.com/momentohq/momento-php-redis-client/issues/39