### PR TITLE
chore: add error info

### DIFF
--- a/examples/basic-example.php
+++ b/examples/basic-example.php
@@ -26,6 +26,13 @@ function createMomentoClient(): array
 {
     $authProvider = CredentialProvider::fromEnvironmentVariable("MOMENTO_API_KEY");
     $configuration = Laptop::latest(new StderrLoggerFactory());
+    $newGrpcConfig = $configuration->getTransportStrategy()
+        ->getGrpcConfig()
+        ->withDeadlineMilliseconds(5000)
+        ->withNumGrpcChannels(5);
+    $configuration = $configuration->withTransportStrategy(
+        $configuration->getTransportStrategy()->withGrpcConfig($newGrpcConfig)
+    );
     $client = new CacheClient($configuration, $authProvider, $GLOBALS['ITEM_DEFAULT_TTL_SECONDS']);
     $logger = $configuration->getLoggerFactory()->getLogger("ex:");
     return [$client, $logger];

--- a/src/MomentoCacheClient.php
+++ b/src/MomentoCacheClient.php
@@ -407,6 +407,9 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
     }
 
 
+    /**
+     * @throws Exception
+     */
     public function exists(mixed $key, mixed ...$other_keys): Redis|int|bool
     {
         $keys = array_merge([$key], $other_keys);
@@ -456,8 +459,10 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
                 return false;
             } elseif ($result->asMiss()) {
                 return false;
-            } else {
+            } elseif ($result->asError()) {
                 return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+            } else {
+                return false;
             }
         }
 
@@ -1260,6 +1265,9 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         throw MomentoToPhpRedisExceptionMapper::createCommandNotImplementedException(__FUNCTION__);
     }
 
+    /**
+     * @throws Exception
+     */
     public function pttl(string $key): Redis|int|false
     {
         $result = $this->client->itemGetTtl($this->cacheName, $key);
@@ -1583,6 +1591,8 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         $result = $this->client->set($this->cacheName, $key, $value, $ttl);
         if ($result->asSuccess()) {
             return 'OK';
+        } else if ($result->asError()) {
+            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
         } else {
             return false;
         }

--- a/src/MomentoCacheClient.php
+++ b/src/MomentoCacheClient.php
@@ -328,7 +328,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         foreach ($keys as $key) {
             $result = $this->client->delete($this->cacheName, $key);
             if ($result->asError()) {
-                return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+                return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "delete");
             }
         }
         return count($keys);
@@ -418,7 +418,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
             $resp = $result->asSuccess()->exists();
             return array_sum($resp);
         } elseif ($result->asError()) {
-            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "keysExist");
         } else {
             return false;
         }
@@ -446,7 +446,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
             } elseif ($result->asMiss()) {
                 return false;
             } elseif ($result->asError()) {
-                return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+                return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "decreaseTtl");
             } else {
                 return false;
             }
@@ -460,7 +460,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
             } elseif ($result->asMiss()) {
                 return false;
             } elseif ($result->asError()) {
-                return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+                return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "increaseTtl");
             } else {
                 return false;
             }
@@ -473,7 +473,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         } elseif ($result->asMiss()) {
             return false;
         } elseif ($result->asError()) {
-            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "updateTtl");
         } else {
             return false;
         }
@@ -639,7 +639,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         } elseif ($result->asMiss()) {
             return false;
         } elseif ($result->asError()) {
-            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "get");
         } else {
             return false;
         }
@@ -931,7 +931,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         if ($result->asSuccess()) {
             return $result->asSuccess()->value();
         } elseif ($result->asError()) {
-            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "increment");
         } else {
             return false;
         }
@@ -1276,7 +1276,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         } else if ($result->asMiss()) {
             return -2;
         } else {
-            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "itemGetTtl");
         }
     }
 
@@ -1568,7 +1568,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
                 } elseif ($result->asNotStored()) {
                     return false;
                 } elseif ($result->asError()) {
-                    return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+                    return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "setIfAbsent");
                 } else {
                     return false;
                 }
@@ -1580,7 +1580,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
                 } elseif ($result->asNotStored()) {
                     return false;
                 } elseif ($result->asError()) {
-                    return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+                    return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "setIfPresent");
                 } else {
                     return false;
                 }
@@ -1592,7 +1592,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         if ($result->asSuccess()) {
             return 'OK';
         } else if ($result->asError()) {
-            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "set");
         } else {
             return false;
         }
@@ -1641,7 +1641,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         } else if ($result->asNotStored()) {
             return false;
         } else {
-            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "setIfAbsent");
         }
     }
 
@@ -1809,7 +1809,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         } else if ($result->asMiss()) {
             return -2;
         } else {
-            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "itemGetTtl");
         }
     }
 
@@ -2001,7 +2001,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         if ($result->asSuccess()) {
             return count($elements);
         } elseif ($result->asError()) {
-            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "sortedSetPutElements");
         } else {
             return false;
         }
@@ -2036,7 +2036,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         } elseif ($result->asMiss()) {
             return 0;
         } elseif ($result->asError()) {
-            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "sortedSetLengthByScore");
         } else {
             return false;
         }
@@ -2051,7 +2051,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         if ($result->asSuccess()) {
             return $result->asSuccess()->score();
         } elseif ($result->asError()) {
-            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "sortedSetIncrementScore");
         } else {
             return false;
         }
@@ -2157,7 +2157,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         if ($result->asSuccess()) {
             return count($members);
         } elseif ($result->asError()) {
-            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "sortedSetRemoveElements");
         } else {
             return false;
         }
@@ -2216,7 +2216,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         } elseif ($result->asMiss()) {
             return [];
         } elseif ($result->asError()) {
-            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "sortedSetFetchByRank");
         } else {
             return false;
         }
@@ -2281,7 +2281,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         } elseif ($result->asMiss()) {
             return [];
         } elseif ($result->asError()) {
-            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "sortedSetFetchByScore");
         } else {
             return false;
         }
@@ -2306,7 +2306,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         } elseif ($result->asMiss()) {
             return false;
         } elseif ($result->asError()) {
-            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "sortedSetGetScore");
         } else {
             return false;
         }
@@ -2395,7 +2395,7 @@ class MomentoCacheClient extends Redis implements IMomentoRedisClient
         if ($result->asSuccess()) {
             return $result->asSuccess()->length();
         } elseif ($result->asError()) {
-            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result);
+            return MomentoToPhpRedisExceptionMapper::mapExceptionElseReturnFalse($result, "sortedSetUnionStore");
         } else {
             return false;
         }

--- a/src/Utils/MomentoToPhpRedisExceptionMapper.php
+++ b/src/Utils/MomentoToPhpRedisExceptionMapper.php
@@ -12,11 +12,11 @@ class MomentoToPhpRedisExceptionMapper
     /**
      * @throws RedisException
      */
-    public static function mapExceptionElseReturnFalse($error): bool|RedisException
+    public static function mapExceptionElseReturnFalse($error, $apiName): bool|RedisException
     {
         $sdkError = $error->asError()->innerException();
         if (get_class($sdkError) === TimeoutError::class) {
-            $errorDetails = "{$sdkError->getMessage()}\nTraceback:\n-----\n{$sdkError->getTraceAsString()}\n-----\n";
+            $errorDetails = "$apiName returned error {$sdkError->getMessage()}\n";
             throw new RedisException("Timeout occurred: " . $errorDetails);
         }
         return false;

--- a/src/Utils/MomentoToPhpRedisExceptionMapper.php
+++ b/src/Utils/MomentoToPhpRedisExceptionMapper.php
@@ -15,10 +15,11 @@ class MomentoToPhpRedisExceptionMapper
     public static function mapExceptionElseReturnFalse($error): bool|RedisException
     {
         $sdkError = $error->asError()->innerException();
-        return match (get_class($sdkError)) {
-            TimeoutError::class => throw new RedisException("Timeout occurred: " . $sdkError->getMessage()),
-            default => false,
-        };
+        if (get_class($sdkError) === TimeoutError::class) {
+            $errorDetails = "{$sdkError->getMessage()}\nTraceback:\n-----\n{$sdkError->getTraceAsString()}\n-----\n";
+            throw new RedisException("Timeout occurred: " . $errorDetails);
+        }
+        return false;
     }
 
     public static function createCommandNotImplementedException(string $command): NotImplementedException


### PR DESCRIPTION
This commit standardizes error handling in the `pttl` and `set` functions, which were previously returning false on error rather than using the `mapExceptionElseReturnFalse` function like all the other functions. We also add the traceback from the Momento SDK error in the `RedisException` error message so we can determine which API call produced the error.

The basic example is also updated to configure the Momento client to use 5 gRPC channels instead of the default of 1.